### PR TITLE
用zhsq:mvc标签 启动 请求监听服务成功

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 #Other files
 *.a
 .gitignore
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+#Eclipse project files
 /target/
 *.class
 .settings/
@@ -5,3 +6,10 @@
 *.classpath
 *.class
 */target
+
+#Intellij project files
+*.idea
+*.iml
+
+#Other files
+*.a

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/target/
+*.class
+.settings/
+*.project
+*.classpath
+*.class
+*/target

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 #Other files
 *.a
+.gitignore

--- a/pom.xml
+++ b/pom.xml
@@ -1,28 +1,34 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.zsq.cn</groupId>
-  <artifactId>zhsq-mvc</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <packaging>pom</packaging>
+	<groupId>com.zsq.cn</groupId>
+	<artifactId>zhsq-mvc</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
-  <name>zhsq-mvc</name>
-  <url>http://maven.apache.org</url>
+	<name>zhsq-mvc</name>
+	<url>http://maven.apache.org</url>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-  <modules>
-  	<module>zhsq-mvc-transport</module>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.1</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework/spring-context -->
+	</dependencies>
+	<modules>
+		<module>zhsq-mvc-transport</module>
+		<module>zhsq-mvc-web</module>
+		<module>zhsq-mvc-webmvc</module>
+		<module>zhsq-mvc-config</module>
+    <module>zhsq-mvc-common</module>
+    <module>zhsq-mvc-example</module>
   </modules>
 </project>

--- a/zhsq-mvc-common/pom.xml
+++ b/zhsq-mvc-common/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.zsq.cn</groupId>
+    <artifactId>zhsq-mvc</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <groupId>com.zsq.cn</groupId>
+  <artifactId>zhsq-mvc-common</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>zhsq-mvc-common</name>
+  <url>http://maven.apache.org</url>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/zhsq-mvc-config/pom.xml
+++ b/zhsq-mvc-config/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.zsq.cn</groupId>
+		<artifactId>zhsq-mvc</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+	<groupId>com.zsq.cn</groupId>
+	<artifactId>zhsq-mvc-config</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>zhsq-mvc-config</name>
+	<url>http://maven.apache.org</url>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<spring.context.version>5.0.3.RELEASE</spring.context.version>
+		<zhsq.mvc.transport.version>0.0.1-SNAPSHOT</zhsq.mvc.transport.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>${spring.context.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.zsq.cn</groupId>
+			<artifactId>zhsq-mvc-transport</artifactId>
+			<version>${zhsq.mvc.transport.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/zhsq-mvc-config/src/main/java/org/zhsq/mvc/config/AbstractConfig.java
+++ b/zhsq-mvc-config/src/main/java/org/zhsq/mvc/config/AbstractConfig.java
@@ -1,0 +1,56 @@
+package org.zhsq.mvc.config;
+
+import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 基础配置,主要是对一些基础配置进行定义和校验
+ * @author zhaosq
+ * @date 2018年5月12日
+ * @since 1.0
+ */
+public abstract class AbstractConfig implements Serializable {
+
+	private static final long serialVersionUID = -5013591462121099116L;
+
+	private static final Pattern PATTERN_CONFIG_VALUE = Pattern.compile("[\\-._0-9a-zA-Z]+");
+
+	private static final Pattern PATTERN_NUMBER = Pattern.compile("^\\d+$");
+
+	private static final int MAX_LENGTH = 200;
+
+
+
+	protected void checkProperty(String key, String value) {
+		checkProperty(key,value,MAX_LENGTH,PATTERN_CONFIG_VALUE);
+	}
+
+	protected void checkProperty(String key, String value, Pattern pattern) {
+		checkProperty(key,value,MAX_LENGTH,pattern);
+	}
+
+	protected void checkNumber(String key, String value) {
+		checkProperty(key,value,MAX_LENGTH,PATTERN_NUMBER);
+	}
+
+	private static void checkProperty(String property, String value, int maxlength, Pattern pattern) {
+		if (value == null || value.length() == 0) {
+			return;
+		}
+		if (value.length() > maxlength) {
+			throw new IllegalStateException("属性" + property + "=\"" + value + "\" 超过最大长度 " + maxlength);
+		}
+		if (pattern != null) {
+			Matcher matcher = pattern.matcher(value);
+			if (!matcher.matches()) {
+				throw new IllegalStateException("属性 " + property + "=\"" + value + "\" 不能地匹配正则表达式:"+pattern.pattern());
+			}
+		}
+	}
+
+
+
+
+
+}

--- a/zhsq-mvc-config/src/main/java/org/zhsq/mvc/config/ServerConfig.java
+++ b/zhsq-mvc-config/src/main/java/org/zhsq/mvc/config/ServerConfig.java
@@ -1,0 +1,146 @@
+/**
+ * 
+ */
+package org.zhsq.mvc.config;
+
+import java.util.regex.Pattern;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.zhsq.mvc.transport.server.NettyServer;
+
+import io.netty.util.internal.StringUtil;
+
+/**
+ * netty服务监听获取请求信息
+ * @author zhaosq
+ * @date 2018年5月12日
+ * @since 1.0
+ */
+public class ServerConfig extends AbstractConfig implements ApplicationListener<ContextRefreshedEvent> {
+
+
+	private static final long serialVersionUID = -3326397664502103849L;
+
+	private static final Pattern PATTERN_IPV4 = Pattern.compile("^(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}$");
+
+	private static final int MAX_PORT = 65535;
+
+	private static final String DEFAULT_IP = "127.0.0.1";
+
+	private String name;
+
+	private String ip;
+
+	private int port;
+
+	private int bossThreads;
+
+	private int workerThreads;
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the ip
+	 */
+	public String getIp() {
+		return ip;
+	}
+
+	/**
+	 * @param ip the ip to set
+	 */
+	public void setIp(String ip) {
+		this.ip = ip;
+	}
+
+	/**
+	 * @return the port
+	 */
+	public int getPort() {
+		return port;
+	}
+
+	/**
+	 * @param port the port to set
+	 */
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	/**
+	 * @return the bossThreads
+	 */
+	public int getBossThreads() {
+		return bossThreads;
+	}
+
+	/**
+	 * @param bossThreads the bossThreads to set
+	 */
+	public void setBossThreads(int bossThreads) {
+		this.bossThreads = bossThreads;
+	}
+
+	/**
+	 * @return the workerThreads
+	 */
+	public int getWorkerThreads() {
+		return workerThreads;
+	}
+
+	/**
+	 * @param workerThreads the workerThreads to set
+	 */
+	public void setWorkerThreads(int workerThreads) {
+		this.workerThreads = workerThreads;
+	}
+
+
+	@Override
+	public String toString() {
+		return "ServerConfig [name=" + name + ", ip=" + ip + ", port=" + port
+				+ ", bossThreads=" + bossThreads + ", workerThreads=" + workerThreads + "]";
+	}
+
+	@Override
+	public void onApplicationEvent(ContextRefreshedEvent event) {
+		//校验ip port 以及超时参数
+		if (StringUtil.isNullOrEmpty(ip)) {
+			ip = DEFAULT_IP;
+		}
+
+		checkProperty("ip", ip,PATTERN_IPV4);
+		checkPort();
+
+		//开启请求监听服务
+		startServer();
+	}
+
+	private void startServer() {
+		new NettyServer().bind(ip, port, bossThreads, workerThreads);
+	}
+
+	private void checkPort() {
+		if (port == 0) {
+			//服务监听端口默认为 80
+			port = 80;
+			return ;
+		}
+		if (port < 0 || port > MAX_PORT) {
+			throw new IllegalArgumentException("端口号必须介于 0 - 66535 之间!");
+		}
+	}
+}

--- a/zhsq-mvc-config/src/main/java/org/zhsq/mvc/config/spring/schema/ServerBeanDefinitionParser.java
+++ b/zhsq-mvc-config/src/main/java/org/zhsq/mvc/config/spring/schema/ServerBeanDefinitionParser.java
@@ -1,0 +1,59 @@
+package org.zhsq.mvc.config.spring.schema;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+
+/**
+ * 解析zhsq:server 标签
+ * @author zhaosq
+ * @date 2018年5月12日
+ * @since 1.0
+ */
+public class ServerBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+	private final Class<?> beanClass;
+
+
+	public ServerBeanDefinitionParser (Class<?> beanClass) {
+		this.beanClass = beanClass;
+	}
+
+
+	@Override
+	protected Class<?> getBeanClass(Element element) {
+		return beanClass;
+	}
+	
+	@Override
+	protected boolean shouldGenerateId() {
+		return true;
+	}
+
+
+	@Override
+	protected void doParse(Element element, BeanDefinitionBuilder bean) {
+		String name = element.getAttribute("name");
+		String ip = element.getAttribute("ip");
+		String port = element.getAttribute("port");
+		String bossThreads = element.getAttribute("bossThreads");
+		String workerThreads = element.getAttribute("workerThreads");
+
+		if (StringUtils.hasText(name)) {
+			bean.addPropertyValue("name", name);
+		}
+		if (StringUtils.hasText(ip)) {
+			bean.addPropertyValue("ip", ip);
+		}
+		if (StringUtils.hasText(port)) {
+			bean.addPropertyValue("port", port);
+		}
+		if (StringUtils.hasText(bossThreads)) {
+			bean.addPropertyValue("bossThreads", bossThreads);
+		}
+		if (StringUtils.hasText(workerThreads)) {
+			bean.addPropertyValue("workerThreads", workerThreads);
+		}
+	}
+}

--- a/zhsq-mvc-config/src/main/java/org/zhsq/mvc/config/spring/schema/ZhsqNameSpaceHandler.java
+++ b/zhsq-mvc-config/src/main/java/org/zhsq/mvc/config/spring/schema/ZhsqNameSpaceHandler.java
@@ -1,0 +1,20 @@
+package org.zhsq.mvc.config.spring.schema;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+import org.zhsq.mvc.config.ServerConfig;
+
+
+/**
+ * xml文件中"zhsq:xxx" 标签解析器
+ * @author zhaosq
+ * @date 2018年5月12日
+ * @since 1.0
+ */
+public class ZhsqNameSpaceHandler extends NamespaceHandlerSupport {
+
+	@Override
+	public void init() {
+		//请求监听服务启动配置解析器
+		registerBeanDefinitionParser("server", new ServerBeanDefinitionParser(ServerConfig.class));
+	}
+}

--- a/zhsq-mvc-config/src/main/resources/META-INF/Spring.handlers
+++ b/zhsq-mvc-config/src/main/resources/META-INF/Spring.handlers
@@ -1,0 +1,1 @@
+http\://www.zsq.com/schema/zhsq=org.zhsq.mvc.config.spring.schema.ZhsqNameSpaceHandler

--- a/zhsq-mvc-config/src/main/resources/META-INF/Spring.schemas
+++ b/zhsq-mvc-config/src/main/resources/META-INF/Spring.schemas
@@ -1,0 +1,1 @@
+http\://www.zsq.com/schema/zhsq.xsd=META-INF/zhsq.xsd

--- a/zhsq-mvc-config/src/main/resources/META-INF/zhsq.xsd
+++ b/zhsq-mvc-config/src/main/resources/META-INF/zhsq.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns="http://www.zsq.com/schema/zhsq" xmlns:tool="http://www.springframework.org/schema/tool"
+	targetNamespace="http://www.zsq.com/schema/zhsq">
+
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+
+	<xsd:element name="server">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[ 请求监听服务配置 ]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="ip" type="xsd:string" use="required" />
+			<xsd:attribute name="port" type="xsd:integer" use="required" />
+			<xsd:attribute name="name" type="xsd:string" use="optional" />
+			<xsd:attribute name="bossThreads" type="xsd:integer" use="optional" />
+			<xsd:attribute name="workerThreads" type="xsd:integer" use="optional" />
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>

--- a/zhsq-mvc-example/pom.xml
+++ b/zhsq-mvc-example/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.zsq.cn</groupId>
+		<artifactId>zhsq-mvc</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+	<groupId>com.zsq.cn</groupId>
+	<artifactId>zhsq-mvc-example</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>zhsq-mvc-example</name>
+	<url>http://maven.apache.org</url>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.1</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-demo-api</artifactId>
+			<version>2.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-config-spring</artifactId>
+			<version>2.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-registry-multicast</artifactId>
+			<version>2.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-rpc-dubbo</artifactId>
+			<version>2.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-remoting-netty</artifactId>
+			<version>2.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-serialization-hessian2</artifactId>
+			<version>2.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>dubbo-container-spring</artifactId>
+			<version>2.6.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.zsq.cn</groupId>
+			<artifactId>zhsq-mvc-config</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
+		</resources>
+	</build>
+
+</project>

--- a/zhsq-mvc-example/src/main/resources/META-INF/spring/dubbo-demo-consumer.xml
+++ b/zhsq-mvc-example/src/main/resources/META-INF/spring/dubbo-demo-consumer.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	You under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://www.springframework.org/schema/beans" xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"
+	xmlns:zhsq="http://www.zsq.com/schema/zhsq"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+       http://code.alibabatech.com/schema/dubbo http://code.alibabatech.com/schema/dubbo/dubbo.xsd
+       http://www.zsq.com/schema/zhsq http://www.zsq.com/schema/zhsq.xsd ">
+
+
+	<dubbo:application name="demo-consumer" />
+
+	<dubbo:registry address="multicast://224.5.6.7:1234" />
+
+
+	<dubbo:reference id="demoService" check="false"
+		interface="com.alibaba.dubbo.demo.DemoService" />
+
+	<zhsq:server ip="127.0.0.1" port="80" />
+</beans>

--- a/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/DefaultChildHandler.java
+++ b/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/DefaultChildHandler.java
@@ -1,14 +1,15 @@
 package org.zhsq.mvc.transport.server;
 
-import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
-import io.netty.channel.ChannelHandlerAdapter;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
 
+/**
+ * @author zhaosq
+ * @date 2018年5月11日
+ */
 public class DefaultChildHandler extends ChannelInitializer<SocketChannel>{
 
 	@Override

--- a/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/NettyServer.java
+++ b/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/NettyServer.java
@@ -25,6 +25,8 @@ public class NettyServer {
 			.option(ChannelOption.SO_BACKLOG, 100)
 			.handler(new LoggingHandler(LogLevel.INFO))
 			.childHandler(new DefaultChildHandler());
+			
+			
 			ChannelFuture future = sb.bind("127.0.0.1", 80).sync();
 			future.channel().closeFuture().sync();
 

--- a/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/NettyServer.java
+++ b/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/NettyServer.java
@@ -1,22 +1,28 @@
 package org.zhsq.mvc.transport.server;
 
+import org.zhsq.mvc.transport.server.exception.ServerBindException;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.util.internal.StringUtil;
 
+/**
+ * 请求监听服务
+ * @author zhaosq
+ * @date 2018年5月11日
+ */
 public class NettyServer {
 
-	public void bind () throws InterruptedException {
+	public void bind (String ip, int port, int boss, int worker) throws ServerBindException {
 
-		EventLoopGroup bossGroup = new NioEventLoopGroup();
-		EventLoopGroup workerGroup = new NioEventLoopGroup();
+		EventLoopGroup bossGroup = new NioEventLoopGroup(boss == 0 ? 1 : boss);
+		EventLoopGroup workerGroup = new NioEventLoopGroup(worker);
 
 		try {
 			ServerBootstrap sb = new ServerBootstrap();
@@ -25,11 +31,12 @@ public class NettyServer {
 			.option(ChannelOption.SO_BACKLOG, 100)
 			.handler(new LoggingHandler(LogLevel.INFO))
 			.childHandler(new DefaultChildHandler());
-			
-			
-			ChannelFuture future = sb.bind("127.0.0.1", 80).sync();
+
+			ChannelFuture future = sb.bind(ip, port).sync();
 			future.channel().closeFuture().sync();
 
+		} catch (InterruptedException e) {
+			throw new ServerBindException("请求监听服务 绑定失败："+e.getMessage(),e);
 		} finally {
 			bossGroup.shutdownGracefully();
 			workerGroup.shutdownGracefully();
@@ -37,11 +44,7 @@ public class NettyServer {
 	}
 
 	public static void main (String[] args) {
-		try {
-			new NettyServer().bind();
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
+//		new NettyServer().bind("127.0.0.1",80,1,10);
 	}
 
 

--- a/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/NettyServerHandler.java
+++ b/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/NettyServerHandler.java
@@ -12,12 +12,18 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.CharsetUtil;
 
+/**
+ * @author zhaosq
+ * @date 2018年5月11日
+ */
 public class NettyServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
 
 	@Override
 	protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
 		String uri = request.uri();
-		System.out.println(uri);
+		
+		//TODO 这里根据获取到的uri 经过自己的dispatcher 访问自己的控制器 现在已经通过netty的http获取到  http请求了
+		
 		
 		FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
 		response.headers().set("Content-Type", "text/html;charset=UTF-8");

--- a/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/exception/ServerBindException.java
+++ b/zhsq-mvc-transport/src/main/java/org/zhsq/mvc/transport/server/exception/ServerBindException.java
@@ -1,0 +1,24 @@
+/**
+ * 
+ */
+package org.zhsq.mvc.transport.server.exception;
+
+/**
+ * 服务启动异常
+ * @author zhaosq
+ * @date 2018年5月12日
+ * @since 1.0
+ */
+public class ServerBindException extends RuntimeException {
+
+	private static final long serialVersionUID = -3038379449152601310L;
+
+	public ServerBindException (String message) {
+		super(message);
+	}
+
+	public ServerBindException (String message, Exception e) {
+		super(message, e);
+	}
+
+}

--- a/zhsq-mvc-web/pom.xml
+++ b/zhsq-mvc-web/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.zsq.cn</groupId>
+		<artifactId>zhsq-mvc</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+	<groupId>com.zsq.cn</groupId>
+	<artifactId>zhsq-mvc-web</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>zhsq-mvc-web</name>
+	<url>http://maven.apache.org</url>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<spring.context.version>5.0.3.RELEASE</spring.context.version>
+		<zhsq.mvc.transport.version>0.0.1-SNAPSHOT</zhsq.mvc.transport.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.1</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework/spring-context -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>${spring.context.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.zsq.cn</groupId>
+			<artifactId>zhsq-mvc-transport</artifactId>
+			<version>${zhsq.mvc.transport.version}</version>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/dispatcher/HttpRequestDefaultDispatcher.java
+++ b/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/dispatcher/HttpRequestDefaultDispatcher.java
@@ -1,0 +1,50 @@
+package org.zhsq.mvc.web.dispatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.zhsq.mvc.web.filter.Filter;
+import org.zhsq.mvc.web.intercepter.HttpIntercepter;
+import org.zhsq.mvc.web.intercepter.Intercepter;
+
+/**
+ * HTTP协议请求默认调度控制器
+ * @author zhaosq
+ * @date 2018年5月11日
+ * @since 1.0
+ */
+public class HttpRequestDefaultDispatcher {
+
+	/**
+	 * 当请求路径前缀匹配 prefix时调度器才会起作用
+	 */
+	private String prefix;
+
+	/**
+	 * web上下文配置文件加载路径
+	 */
+	private String contextConfigLocation;
+	/**
+	 * 为当前调度器配置拦截器
+	 */
+	private final List<HttpIntercepter> interceptors = new ArrayList<HttpIntercepter>(10);
+	/**
+	 * 为当前调度器配置过滤器
+	 */
+	private final List<Filter> filters = new ArrayList<Filter>(10);
+
+
+	//	我觉得是在 dispatcher 中维护自己的 拦截器链和过滤器链 
+	//	包括生成拦截器链和过滤器链  以及 调用下一个 拦截器和过滤器
+
+
+
+
+
+
+
+
+
+
+
+}

--- a/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/filter/Filter.java
+++ b/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/filter/Filter.java
@@ -1,0 +1,26 @@
+/**
+ * 
+ */
+package org.zhsq.mvc.web.filter;
+
+import java.util.List;
+
+/**
+ * @author zhaosq
+ * @date 2018年5月11日
+ * @since 1.0
+ */
+public interface Filter {
+
+	/**
+	 * 获取过滤器链中下一个过滤器
+	 * @return 
+	 */
+	Filter next();
+	
+	/**获取过滤器链
+	 * @return 过滤器链
+	 */
+	List<Filter> filterChain();
+	
+}

--- a/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/filter/HttpFilter.java
+++ b/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/filter/HttpFilter.java
@@ -1,0 +1,13 @@
+/**
+ * 
+ */
+package org.zhsq.mvc.web.filter;
+
+/**
+ * @author zhaosq
+ * @date 2018年5月11日
+ * @since 1.0
+ */
+public interface HttpFilter {
+
+}

--- a/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/handler/HandlerMapping.java
+++ b/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/handler/HandlerMapping.java
@@ -1,0 +1,13 @@
+/**
+ * 
+ */
+package org.zhsq.mvc.web.handler;
+
+/**
+ * 在@ZController标注的类中为@ZRequestMapping配置handler信息
+ * @author zhaosq
+ * @date 2018年5月11日
+ */
+public interface HandlerMapping {
+
+}

--- a/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/intercepter/HttpIntercepter.java
+++ b/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/intercepter/HttpIntercepter.java
@@ -1,0 +1,26 @@
+/**
+ * 
+ */
+package org.zhsq.mvc.web.intercepter;
+
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+
+/**
+ * HTTP协议请求处理的拦截器
+ * @author zhaosq
+ * @date 2018年5月11日
+ * @since 1.0
+ */
+public interface HttpIntercepter extends Intercepter {
+
+	/**
+	 * 拦截请求
+	 * @param request HTTP请求信息
+	 * @param response HTTP响应信息
+	 * @param next 下一个拦截器
+	 * @return 拦截是否通过,true：通过拦截调用进入Filter ;false：未通过拦截调用通过response返回信息
+	 */
+	boolean intercept (HttpRequest request, HttpResponse response, HttpIntercepter next);
+
+}

--- a/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/intercepter/Intercepter.java
+++ b/zhsq-mvc-web/src/main/java/org/zhsq/mvc/web/intercepter/Intercepter.java
@@ -1,0 +1,28 @@
+/**
+ * 
+ */
+package org.zhsq.mvc.web.intercepter;
+
+import java.util.List;
+
+/**
+ * 处理请求的拦截器
+ * @author zhaosq
+ * @date 2018年5月11日
+ * @since 1.0
+ */
+public interface Intercepter {
+
+	/**
+	 * 获取拦截器链中的下一个拦截器
+	 * @return 拦截器链中的下一个拦截器
+	 */
+	Intercepter next();
+
+	/**
+	 * 获取拦截器链
+	 * @return 拦截器链
+	 */
+	List<Intercepter> intercepterChain();
+
+}

--- a/zhsq-mvc-webmvc/pom.xml
+++ b/zhsq-mvc-webmvc/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.zsq.cn</groupId>
+    <artifactId>zhsq-mvc</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <groupId>com.zsq.cn</groupId>
+  <artifactId>zhsq-mvc-webmvc</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>zhsq-mvc-webmvc</name>
+  <url>http://maven.apache.org</url>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
新建了config common example web webmvc 模块 并在config模块新建了自定义标签zhsq:mvc 用来启动transport模块的请求监听服务 在新建的example模块中已经测试 请求监听成功