### PR TITLE
解析webApplicationContext中通过@RequestMapping注解的bean,以及方法。缓存对应路径与bean,方便DefaultAnnotationHandlerMapping根据请求路径获取controller。以及创建并注册DefaultAnnotationHandlerMapping的bean

### DIFF
--- a/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/context/ZhsqWebApplicationContext.java
+++ b/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/context/ZhsqWebApplicationContext.java
@@ -2,8 +2,10 @@ package org.zhsq.mvc.handle.context;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.zhsq.mvc.handle.handle.AnnotationMethodHandler;
 import org.zhsq.mvc.handle.handle.DefaultAnnotationHandlermapping;
 
 /**
@@ -26,12 +28,25 @@ public class ZhsqWebApplicationContext {
 			throw new RuntimeException("请为WebApplicationContextLoaderConfig指定configLocation值...");
 		}
 
+		//加载webApplicationContext上下文
 		webApplicationContext = new ClassPathXmlApplicationContext(configLocation.split("[,\\s]+"));
 		webApplicationContext.setParent(rootApplicationContext);
 		webApplicationContext.start();
+
+		//获取beanfactory
+		DefaultListableBeanFactory factory = (DefaultListableBeanFactory) webApplicationContext.getAutowireCapableBeanFactory();
+
+		/**通过beanFactory获取并注册bean*/
+
 		//将DefaultAnnotationHandlermapping注册为单实例bean,并调用其init方法对@RequestMapping()注解的bean进行捕获
 		//以便以便后期根据URL获取handler
-		webApplicationContext.getAutowireCapableBeanFactory().createBean(DefaultAnnotationHandlermapping.class);
+		DefaultAnnotationHandlermapping bean = factory.createBean(DefaultAnnotationHandlermapping.class);
+		factory.registerSingleton(DefaultAnnotationHandlermapping.class.getName(), bean);
+
+		//实例化AnnotationMethodHandler.calss的bean对webApplicationContext进行后处理
+		//主要是对webApplicationContext中RequestMapping注解的类和方法解析和缓存
+//		AnnotationMethodHandler bean2 = factory.createBean(AnnotationMethodHandler.class);
+//		factory.registerSingleton(AnnotationMethodHandler.class.getName(), bean2);
 	}
 
 

--- a/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/dispatcer/HttpRequestDefaultDispatcher.java
+++ b/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/dispatcer/HttpRequestDefaultDispatcher.java
@@ -105,6 +105,9 @@ public class HttpRequestDefaultDispatcher implements HttpDispatcher, Application
 		//TODO 获取handler后 如何处理请参考springMvc  注意处理对request.uri()进行 prefix处理 以及参数处理
 		Object handler = handlermapping.getHandler(request.uri());
 
+		//TODO 通过 AnnotationMethodHandler.class 获取methodHandler,需要先将AnnotationMethodHandler.class在ZhsqWebApplicationContext.start()
+		//方法中创建并注册bean
+
 
 	}
 

--- a/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/handle/AnnotationMethodHandler.java
+++ b/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/handle/AnnotationMethodHandler.java
@@ -1,0 +1,49 @@
+package org.zhsq.mvc.handle.handle;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.propertyeditors.CurrencyEditor;
+import org.springframework.core.BridgeMethodResolver;
+import org.springframework.util.ClassUtils;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+
+public class AnnotationMethodHandler implements BeanFactoryPostProcessor {
+
+	//缓存webApplicationContext中RequestMapping注解的类和方法解
+	private static final Map<Class<?>, List<Map<String, Method>>> cachedClassMethod = new ConcurrentHashMap<>(100);
+
+	public void invokeHandlerMethod (FullHttpRequest request, FullHttpResponse response, Object handler) {
+
+		//		Class<?> handlerClass = ClassUtils.getUserClass(handler);
+		//		//		String lookupPath = request.uri()
+		//		String lookupPath = "/test/hello";
+		//
+		//		//		ServletHandlerMethodResolver methodResolver = getMethodResolver(handler);
+		//
+		//
+		//		Method handlerMethod = methodResolver.resolveHandlerMethod(request);
+		//		Method handlerMethodToInvoke = BridgeMethodResolver.findBridgedMethod(handlerMethod);
+		//
+		//		Object[] args = new Object[1];
+		//
+		//		return handlerMethodToInvoke.invoke(handler, args);
+
+
+	}
+
+	@Override
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+
+
+
+	}
+
+}

--- a/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/handle/DefaultAnnotationHandlermapping.java
+++ b/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/handle/DefaultAnnotationHandlermapping.java
@@ -24,6 +24,8 @@ import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 import org.zhsq.mvc.handle.annotation.RequestMapping;
 
+import io.netty.handler.codec.http.FullHttpRequest;
+
 /**
  * webApplicationContext加载后，对org.zhsq.mvc.handle.annotation.RequestMapping注解
  * 的bean 以及方法进行捕获并放入handlerMap，以便后期根据URL获取handler
@@ -224,6 +226,11 @@ public class DefaultAnnotationHandlermapping implements ApplicationContextAware,
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		webApplicationContext = applicationContext;
+	}
+
+
+	public Object getHandler(String requestUri) {
+		return handlerMap.get(requestUri);
 	}
 
 }

--- a/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/handle/DefaultAnnotationHandlermapping.java
+++ b/zhsq-mvc-handle/src/main/java/org/zhsq/mvc/handle/handle/DefaultAnnotationHandlermapping.java
@@ -1,10 +1,12 @@
 package org.zhsq.mvc.handle.handle;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -153,7 +155,16 @@ public class DefaultAnnotationHandlermapping implements ApplicationContextAware,
 	}
 
 	protected String[] determineUrlsForHandlerMethods(Class<?> handlerType) {
-		return new String[0];
+		//获取@RequestMapping注解的类中的  @RequestMapping 注解的方法 的路径
+		List<String> methodUrls = new ArrayList<>(10);
+		Method[] mehods = handlerType.getDeclaredMethods();
+		for (Method method : mehods) {
+			if (method.isAnnotationPresent(RequestMapping.class)) {
+				RequestMapping mapping = method.getAnnotation(RequestMapping.class);
+				methodUrls.addAll(Arrays.asList(mapping.value()));
+			}
+		}
+		return methodUrls.toArray(new String[0]);
 	}
 
 	public PathMatcher getPathMatcher() {


### PR DESCRIPTION
解析webApplicationContext中通过@RequestMapping注解的bean,以及方法。缓存对应路径与bean,方便DefaultAnnotationHandlerMapping根据请求路径获取controller。以及创建并注册DefaultAnnotationHandlerMapping的bean